### PR TITLE
Fix rounding of tax_amount to 2 decimal precision

### DIFF
--- a/apps/fyle/models.py
+++ b/apps/fyle/models.py
@@ -149,7 +149,7 @@ class Expense(models.Model):
                     'project_id': expense['project_id'],
                     'expense_number': expense['expense_number'],
                     'org_id': expense['org_id'],
-                    'tax_amount': expense['tax_amount'] if expense['tax_amount'] else 0,
+                    'tax_amount': round(expense['tax_amount'], 2) if expense['tax_amount'] else 0,
                     'tax_group_id': expense['tax_group_id'],
                     'claim_number': expense['claim_number'],
                     'amount': round(expense['amount'], 2),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved accuracy by rounding `tax_amount` and `amount` fields to 2 decimal places in expense entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->