### PR TITLE
docs: add instructions to create the git submodule to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Django Rest Framework API for Fyle Netsuite Integration.
 
 ### Setup
 
+* Add and update the `fyle_integrations_imports` submodule
+    ```bash
+    $ git submodule init
+    $ git submodule update
+    ```
+
 * Download and install Docker desktop for Mac from [here.](https://www.docker.com/products/docker-desktop)
 
 * If you're using a linux machine, please download docker according to the distrubution you're on.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated setup instructions to include the `fyle_integrations_imports` submodule for the Django Rest Framework API for Fyle Netsuite Integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->