### PR TITLE
fix: fix export url generation for sandbox accounts

### DIFF
--- a/fyle_netsuite_api/utils.py
+++ b/fyle_netsuite_api/utils.py
@@ -45,6 +45,9 @@ def generate_netsuite_export_url(response_logs : OrderedDict, netsuite_credentia
     if response_logs:
         try:
             ns_account_id = netsuite_credentials.ns_account_id.lower()
+            if '_sb' in ns_account_id:
+                ns_account_id = ns_account_id.replace('_sb', '-sb')
+
             export_type = response_logs['type'] if 'type' in response_logs and response_logs['type'] else 'chargeCard'
             internal_id = response_logs['internalId']
             redirection = EXPORT_TYPE_REDIRECTION[export_type]

--- a/scripts/sql/scripts/029-update-sandbox-export-urls.sql
+++ b/scripts/sql/scripts/029-update-sandbox-export-urls.sql
@@ -1,0 +1,17 @@
+rollback;
+begin;
+
+-- These values should be swapped after running the script
+-- netsuite=> select count(export_url) from expense_groups where export_url like '%_sb%';
+--  count 
+-- -------
+--    240
+-- (1 row)
+
+-- netsuite=> select count(export_url) from expense_groups where export_url like '%-sb%';
+--  count 
+-- -------
+--      0
+-- (1 row)
+
+update expense_groups set export_url = replace(export_url, '_sb', '-sb');


### PR DESCRIPTION
# Description
The export URLs we generate today look like
```
https://9370982_sb1.app.netsuite.com/app/accounting/transactions/vendbill.nl?id=109903
```

This works for regular netsuite accounts, but not for sandbox ones (notice `sb` in the subdomain name). Netsuite expects a dash `-` instead of an underscore `_`

```
https://9370982-sb1.app.netsuite.com/app/accounting/transactions/vendbill.nl?id=109903
```

This change fixes the export URL generation, as well as patches the incorrect URLs in the database.

## Clickup
https://app.clickup.com/t/86cwzmjkt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced URL generation for NetSuite exports by correctly formatting account IDs containing '_sb'.
	- Introduced a rollback mechanism in the SQL script for updating export URLs in the expense groups table.
- **Bug Fixes**
	- Improved error handling during URL generation to ensure robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->