### PR TITLE
fix: delete `expense_attributes_deletion_cache` in workspace reset

### DIFF
--- a/scripts/sql/functions/reset-workspace.sql
+++ b/scripts/sql/functions/reset-workspace.sql
@@ -253,6 +253,12 @@ BEGIN
     -- GET DIAGNOSTICS rcount = ROW_COUNT;
     -- RAISE NOTICE 'Deleted % workspaces', rcount;
 
+    DELETE
+    FROM expense_attributes_deletion_cache
+    WHERE workspace_id = _workspace_id;
+    GET DIAGNOSTICS rcount = ROW_COUNT;
+    RAISE NOTICE 'Deleted % expense_attributes_deletion_cache', rcount;
+
     UPDATE workspaces
     SET last_synced_at = null, ns_account_id = ''
     WHERE id = _workspace_id;


### PR DESCRIPTION
## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the workspace reset functionality to include deletion of expense attributes related to the workspace.

- **Bug Fixes**
	- Improved data integrity by ensuring that related expense attributes are properly deleted during workspace resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->