### PR TITLE
chore: bump sdk version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ isort==5.10.1
 lazy-object-proxy==1.6.0
 lxml==4.6.5
 mccabe==0.6.1
-netsuitesdk==3.0.0
+netsuitesdk==3.0.1
 oauthlib==3.2.1
 packaging==21.3
 platformdirs==2.4.0


### PR DESCRIPTION
### Description
bump sdk version

## Clickup
https://app.clickup.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Update**
	- Updated NetSuite SDK package to version 3.0.1

<!-- end of auto-generated comment: release notes by coderabbit.ai -->