### PR TITLE
fix: Run container with non root user - 2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,22 @@ RUN mkdir -p /fyle-netsuite-api
 COPY . /fyle-netsuite-api/
 WORKDIR /fyle-netsuite-api
 
+#================================================================
+# Set default GID if not provided during build
+#================================================================
+ARG SERVICE_GID=1001
+
+#================================================================
+# Setup non-root user and permissions
+#================================================================
+RUN groupadd -r -g ${SERVICE_GID} netsuite_api_service && \
+    useradd -r -g netsuite_api_service netsuite_api_user && \
+    mkdir -p /home/netsuite_api_user && \
+    chown -R netsuite_api_user:netsuite_api_service /home/netsuite_api_user && \
+    chmod -R 775 /home/netsuite_api_user && \
+    chown -R netsuite_api_user:netsuite_api_service /fyle-netsuite-api && \
+    chmod -R 775 /fyle-netsuite-api
+
 # Do linting checks
 RUN pylint --load-plugins pylint_django --rcfile=.pylintrc apps/**.py
 


### PR DESCRIPTION

## Clickup
app.clickup.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced container security by configuring the environment to use a dedicated non-root account with improved directory ownership and permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->